### PR TITLE
Build INDI 1.8.3

### DIFF
--- a/libs/cfitsio/cfitsio.py
+++ b/libs/cfitsio/cfitsio.py
@@ -4,7 +4,7 @@ import info
 class subinfo(info.infoclass):
     def setTargets(self):
         for ver in ['3.08', '3.10', '3.14', '3.20', '3.31', '3.35', '3.45']:
-            self.targets[ver] = 'ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio' + ver.replace(".",
+            self.targets[ver] = 'https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio' + ver.replace(".",
                                                                                                       "") + '0.tar.gz'
             self.targetInstSrc[ver] = "cfitsio"
         self.targetDigests['3.20'] = 'f200fe0acba210e88e230add6a4e68d80ad3d4f2'

--- a/libs/indiserver/indiserver.py
+++ b/libs/indiserver/indiserver.py
@@ -10,7 +10,7 @@ class subinfo(info.infoclass):
         self.svnTargets['Latest'] = "https://github.com/indilib/indi.git"
         self.targetInstSrc['Latest'] = ""
         
-        ver = '1.7.8'
+        ver = '1.8.3'
         self.svnTargets[ver] = "https://github.com/indilib/indi.git||v" + ver
         self.archiveNames[ver] = 'indi-%s.tar.gz' % ver
         self.targetInstSrc[ver] = ""

--- a/libs/indiserver3rdParty/indiserver3rdParty.py
+++ b/libs/indiserver3rdParty/indiserver3rdParty.py
@@ -10,8 +10,8 @@ class subinfo(info.infoclass):
         self.svnTargets['Latest'] = "https://github.com/indilib/indi-3rdparty.git"
         self.targetInstSrc['Latest'] = ""
         
-        ver = '1.7.8'
-        self.svnTargets[ver] = "https://github.com/indilib/indi.git||v" + ver
+        ver = '1.8.3'
+        self.svnTargets[ver] = "https://github.com/indilib/indi-3rdparty.git||v" + ver
         self.archiveNames[ver] = 'indi-%s.tar.gz' % ver
         self.targetInstSrc[ver] = ""
 

--- a/libs/indiserver3rdPartyLibraries/indiserver3rdPartyLibraries.py
+++ b/libs/indiserver3rdPartyLibraries/indiserver3rdPartyLibraries.py
@@ -10,8 +10,8 @@ class subinfo(info.infoclass):
         self.svnTargets['Latest'] = "https://github.com/indilib/indi-3rdparty.git"
         self.targetInstSrc['Latest'] = ""
         
-        ver = '1.7.8'
-        self.svnTargets[ver] = "https://github.com/indilib/indi.git||v" + ver
+        ver = '1.8.3'
+        self.svnTargets[ver] = "https://github.com/indilib/indi-3rdparty.git||v" + ver
         self.archiveNames[ver] = 'indi-%s.tar.gz' % ver
         self.targetInstSrc[ver] = ""
 


### PR DESCRIPTION
Hi Rob,

Today I update my INDI Mac build to the new stable version 1.8.3. It look good but I have to make some change here to make it work.
I send you this change to keep a trace of what I do, you can merge or not. Anyway I do the same change with sed in my build script.
 
The change for cfitsio is because FTP is no more available: https://heasarc.gsfc.nasa.gov/docs/FTPWarning.html 

Otherwise I just change the version in the indiserver* script and change to use indi-3rdparty.git because 1.8.3 is only there.
